### PR TITLE
VDP Program search

### DIFF
--- a/docs/_data/navigation_boxes.yml
+++ b/docs/_data/navigation_boxes.yml
@@ -14,3 +14,8 @@
   desc: Connect, learn from, and collaborate with like-minded folks working on making the Internet a safer place 
   icon: heart
   doc: discourse
+
+- title: Programs
+  desc: Search all the currently listed Vulnerability Disclosure Programs and Bug Bounty Programs in the disclose.io database, find details on where to submit security findings, and understand their safe harbor status.
+  icon: menu
+  url: programs/

--- a/docs/_data/navigation_header.yml
+++ b/docs/_data/navigation_header.yml
@@ -12,7 +12,9 @@ left:
 
   - title: Disclosure History
     url: /history/
-
+  
+  - title: VDP Programs
+    url: /programs/
 
 # Navbar right menu navigation links
 

--- a/docs/_includes/boxes.html
+++ b/docs/_includes/boxes.html
@@ -8,7 +8,7 @@
         {% assign container = '' %}
     {% endif %}
 {% else %}
-    {% assign columns = 3 %}
+    {% assign columns = 4 %}
     {% assign container = '' %}
 {% endif %}
 
@@ -23,9 +23,17 @@
 
         <div class="uk-child-width-1-{{ columns }}@m uk-grid-match uk-text-center uk-margin-medium-top" data-uk-grid>
         {% for item in site.data.navigation_boxes %}
+            
             {% if item.title %}
-            {% assign doc_url = item.doc | prepend:"/docs/" | append:"/" %}
-            {% assign doc = site.docs | where:"url", doc_url | first %}
+                {% if item.doc %}
+                    {% assign doc_url = item.doc | prepend:"/docs/" | append:"/" %}
+                    {% assign doc = site.docs | where:"url", doc_url | first %}
+                {% endif %}
+                {% if item.url %}
+                    {% assign doc = item %}
+                    
+                {% endif %}
+                
             <div>
                 <div class="uk-card uk-card-default uk-box-shadow-medium uk-card-hover uk-card-body uk-inline border-radius-large border-xlight">
                     <a class="uk-position-cover" href="{{ doc.url | relative_url }}"></a>

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -1,5 +1,5 @@
 <div{% if site.navbar.sticky %} data-uk-sticky="animation: uk-animation-slide-top; sel-target: .uk-navbar-container; cls-active: uk-navbar-sticky; cls-inactive: uk-navbar-transparent; top: 200"{% endif %}>
-    <nav class="uk-navbar-container">
+    <nav class="uk-navbar-container" >
         <div class="uk-container">
             <div data-uk-navbar>
                 <div class="uk-navbar-left">

--- a/docs/_includes/programs-datatable.html
+++ b/docs/_includes/programs-datatable.html
@@ -1,0 +1,288 @@
+
+<script src="https://code.jquery.com/jquery-3.5.1.js" integrity="sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=" crossorigin="anonymous"></script>
+    
+<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
+<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.10.23/js/dataTables.uikit.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.6.5/js/dataTables.buttons.min.js"></script> 
+<script type="text/javascript" src="https://cdn.datatables.net/buttons/1.6.5/js/buttons.html5.min.js"></script> 
+
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.23/css/dataTables.uikit.min.css" />
+
+
+<div class="uk-container{{container}}">
+        <h2 class="uk-h1 uk-text-center">Current VDP programs</h2>
+    
+
+    <p class="uk-text-lead uk-text-center">Search all the currently listed VDP projects, find details on where to submit bugs and who to speak to<br/><br/></p>
+</div>
+
+<div class="uk-flex uk-flex-center uk-margin-small-top">
+    <div class=" ">
+    <button class="uk-button uk-button-default " id="btnSaveCSV" style="border-radius: 0px;" type="button">Save as CSV</button>
+    <button class="uk-button uk-button-default " id="btnCopyTable" style="border-radius: 0px;" type="button">Copy To Clipboard</button>
+
+<button class="uk-button uk-button-default " style="border-radius: 0px;" type="button">Fields To Show</button>
+<div class="uk-width-large" uk-dropdown="animation: uk-animation-slide-top-small; duration: 300">  
+    <div class="uk-dropdown-grid uk-child-width-1-2@m " uk-grid>
+        <div>
+            <ul class="uk-nav uk-dropdown-nav">
+                <li class="uk-nav-header">Fields</li>
+                <li><a class="toggle-vis " data-column="0" href="#"><span uk-icon="icon: check"></span>Program Name</a></li>
+                <li><a class="toggle-vis" data-column="1" href="#"><span uk-icon="icon: check"></span>Policy URL</a></li>
+                <li><a class="toggle-vis" data-column="2" href="#">Policy URL Status</a></li>
+                <li><a class="toggle-vis" data-column="3" href="#"><span uk-icon="icon: check"></span>Contact URL</a></li>
+                <li><a class="toggle-vis" data-column="4" href="#">Contact Email</a></li>
+                <li><a class="toggle-vis" data-column="5" href="#">Launch Date</a></li>
+                <li><a class="toggle-vis" data-column="6" href="#"><span uk-icon="icon: check"></span>Bounty?</a></li>
+                <li><a class="toggle-vis" data-column="7" href="#">Swag?</a></li>
+                
+            </ul>
+        </div>
+        <div>
+            <ul class="uk-nav uk-dropdown-nav">
+                <li class="uk-nav-header">Fields</li>
+                
+                <li><a class="toggle-vis" data-column="8" href="#">Hall of Fame</a></li>
+                <li><a class="toggle-vis" data-column="9" href="#">Safe Harbor</a></li>
+                <li><a class="toggle-vis" data-column="10" href="#">Public Disclosure</a></li>
+                <li><a class="toggle-vis" data-column="11" href="#">Disclosure Timeline</a></li>
+                <li><a class="toggle-vis" data-column="12" href="#">PGP Key</a></li>
+                <li><a class="toggle-vis" data-column="13" href="#">Hiring</a></li>
+                <li><a class="toggle-vis" data-column="14" href="#">Security TXT</a></li>
+                <li><a class="toggle-vis" data-column="15" href="#">Pref Language</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+</div>
+</div>
+
+
+<div class="hero-search ">
+    
+    <!-- Html Elements for Search -->
+    <div class="uk-position-relative uk-margin-small-top">
+        
+        <form class="uk-search uk-search-default uk-width-1-1" name="search-hero" onsubmit="return false;">
+            <span class="uk-search-icon-flip uk-icon uk-search-icon" data-uk-search-icon=""><svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><circle fill="none" stroke="#000" stroke-width="1.1" cx="9" cy="9" r="7"></circle><path fill="none" stroke="#000" stroke-width="1.1" d="M14,14 L18,18 L14,14 Z"></path></svg></span>
+            <input id="vdp-search" class="uk-search-input uk-box-shadow-large" type="search" placeholder="Search for VDP projects" autocomplete="off" />
+        </form>
+        <ul id="search-hero-results" class="uk-position-absolute uk-width-1-1 uk-list"></ul>
+    </div>
+
+   
+</div>
+
+
+
+<div class="uk-section uk-padding-remove-top">
+
+    
+    
+    <table id="example" class="uk-table uk-table-hover uk-table-striped uk-table-small uk-table-justify">
+        <thead class="thead-dark">
+            <tr>
+                <th>Program Name</th>
+                <th>Policy URL</th>
+                <th>Policy URL Status</th>
+                <th>Contact URL</th>
+                <th>Contact Email</th>
+                <th class="uk-width-small">Launch Date</th>
+                <th class="uk-width-small">Bounty?</th>
+                <th class="uk-width-small">Swag?</th>
+                <th>Hall of Fame</th>
+                <th>Safe Harbor</th>
+                <th>Public Disclosure</th>
+                <th>Disclosure Timeline</th>
+                <th>PGP Key</th>
+                <th>Hiring</th>
+                <th>Security TXT</th>
+                <th>Pref Language</th>
+                
+            </tr>
+        </thead>
+    </table>
+</div>
+
+<!-- Include diode JSON data -->
+<script>
+    var thisDataTable;
+    $(document).ready(function(){
+
+        $('#btnSaveCSV').on( 'click', function (e) { thisDataTable.button(0).trigger()})
+        $('#btnCopyTable').on( 'click', function (e) { thisDataTable.button(1).trigger()})
+        //return 1;
+        $('a.toggle-vis').on( 'click', function (e) {
+            
+            e.preventDefault();
+    
+            // Get the column API object
+            var column = thisDataTable.column( $(this).attr('data-column') );
+            currentvis = column.visible();
+            var currentLink = $(this)
+            if(currentvis == true)
+            {
+                currentLink.children('span').remove();
+            }
+            else
+            {
+                currentLink.prepend('<span uk-icon="icon: check"></span>')
+            }
+            // Toggle the visibility
+            column.visible( ! column.visible() );
+        } );
+
+        //Searchbar
+        $('#vdp-search').keyup(function(){
+            thisDataTable.search( $(this).val() ).draw();
+            })
+        
+            
+
+        var programInformation = [];
+        $.getJSON("https://raw.githubusercontent.com/disclose/diodb/master/program-list.json", function(data){
+            //console.log(data)
+            thisDataTable = $('#example').DataTable( {
+               
+                dom: 'rt<"uk-pagination"ip>',
+                data: data,
+                buttons: [
+                {
+                    extend: 'csvHtml5',
+                    text: 'Save as CSV',
+                    exportOptions: {
+                        modifier: {
+                            page: 'current'
+                        }
+                    }
+                },
+                {
+                    extend: 'copyHtml5',
+                    text: 'Copy Table',
+                    exportOptions: {
+                        modifier: {
+                            page: 'current'
+                        }
+                    }
+                },
+                
+
+            ],
+            columns: [
+              { 
+                "data": "program_name",
+                "defaultContent": "N/A",
+                "visible": true,
+              },
+              { 
+                "data": "policy_url",
+                "defaultContent": "N/A",
+                "visible": true,
+              },
+              { 
+                "data": "policy_url_status",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "contact_url",
+                "defaultContent": "N/A",
+                "visible": true,
+              },
+              { 
+                "data": "contact_email",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "launch_date",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "offers_bounty",
+                "defaultContent": "N/A",
+                "visible": true,
+              },
+              { 
+                "data": "offers_swag",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "hall_of_fame",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "safe_harbor",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "public_disclosure",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "disclosure_timeline_days",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "pgp_key",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "hiring",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "securitytxt_url",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "preferred_languages",
+                "defaultContent": "N/A",
+                "visible": false,
+              },
+              { 
+                "data": "public_disclosure",
+                "defaultContent": "N/A",
+                "visible": false,
+              }
+              
+            ]}          
+            );
+
+            thisDataTable.on('click', 'tbody tr', function() {
+              //console.log('API row values : ', thisDataTable.row(this).data());
+              rowData = thisDataTable.row(this).data();
+              //$('#details').fadeOut().empty()
+              $('#details').empty()
+              for (const [key, value] of Object.entries(rowData)) {
+                //console.log(key, value);
+                if(value != "")
+                {
+                  appendRow = '<div class="row dark">\
+                    <div class="col-sm-4 p-2 border border-dark">' + key + '</div>\
+                    <div class="col-sm-8 p-2 border border-dark">' + value + '</div>\
+                  </div>'
+                  $('#details').append(appendRow)
+                }
+              }
+              //$('#details').fadeIn()
+            })
+
+
+            
+        }).fail(function(){
+            console.log("An error has occurred.");
+        });
+
+        
+    });
+    </script>

--- a/docs/_layouts/standalone.html
+++ b/docs/_layouts/standalone.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+
+{% if page.width == 'expand' %}
+    {{ content }}
+{% else %}
+<div class="uk-section uk-padding-remove-top">
+    <div class="uk-container{% if page.width %} uk-container-{{page.width}}{% endif %}">
+
+        <article class="uk-article">
+
+            <h1 class="uk-article-title">{{ page.title | escape }}</h1>
+
+            <div class="article-content link-primary">
+                {{ content }}
+            </div>
+
+        </article>
+
+    </div>
+</div>
+{% endif %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,9 @@ hero:
     search: true
 ---
 
-{% include boxes.html columns="3" title="Browse topics" subtitle="Let's get started..." %}
+{% include boxes.html columns="4" title="Browse Topics" subtitle="Chose an option that you need help with or search above" %}
+
+{% include videos.html columns="2" title="What's this about?" subtitle="A couple of talks to get you started..." %}
 
 {% include faqs.html multiple="true" title="Frequently asked questions" category="presale" subtitle="Got a quick question? Let's get you a quick answer" %}
 

--- a/docs/programs.md
+++ b/docs/programs.md
@@ -1,0 +1,26 @@
+---
+layout: standalone
+width: large
+---
+<style>
+.container {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding-top: 56.25%; /* 16:9 Aspect Ratio (divide 9 by 16 = 0.5625) */
+}
+
+/* Then style the iframe to fit in the container div with full height and width */
+.responsive-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}
+</style>
+<div class="container">
+<iframe class="responsive-iframe" src="/standalone/programs-datatable-standalone.html"></iframe>
+</div>

--- a/docs/standalone/programs-datatable-standalone.html
+++ b/docs/standalone/programs-datatable-standalone.html
@@ -1,15 +1,26 @@
+<!DOCTYPE html>
+<html lang="en-gb" dir="ltr" class="uk-height-1-1">
 
+    <head>
+      
 <script src="https://code.jquery.com/jquery-3.5.1.js" integrity="sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=" crossorigin="anonymous"></script>
-    
+<!-- UIkit CSS -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.6.16/dist/css/uikit.min.css" />
+
+<!-- UIkit JS -->
+<script src="https://cdn.jsdelivr.net/npm/uikit@3.6.16/dist/js/uikit.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/uikit@3.6.16/dist/js/uikit-icons.min.js"></script>
+
 <script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
 <script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.10.23/js/dataTables.uikit.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.6.5/js/dataTables.buttons.min.js"></script> 
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.6.5/js/buttons.html5.min.js"></script> 
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.23/css/dataTables.uikit.min.css" />
-
-
-<div class="uk-container{{container}}">
+</head>
+<body>
+<div class="uk-container">
+<div class="uk-container">
         <h2 class="uk-h1 uk-text-center">Current VDP programs</h2>
     
 
@@ -75,7 +86,7 @@
 
 
 
-<div class="uk-section uk-padding-remove-top">
+<div class="uk-section">
 
     
     
@@ -103,7 +114,7 @@
         </thead>
     </table>
 </div>
-
+</div>
 <!-- Include diode JSON data -->
 <script>
     var thisDataTable;
@@ -144,7 +155,7 @@
             //console.log(data)
             thisDataTable = $('#example').DataTable( {
                
-                dom: 'rt<"uk-pagination"ip>',
+                dom: 'rtip',
                 data: data,
                 buttons: [
                 {
@@ -286,3 +297,5 @@
         
     });
     </script>
+
+</body>


### PR DESCRIPTION
Updated docs site to include a new page "programs", which is a new template "standalone" and includes an iframe. Page itself is a Datatables object using native UIKit that loads the VDP programs from the Disclose.io GitHub page, and should be dynamic. Anyone can also download the page and run it to also have it. An example of it as follows:

![image](https://user-images.githubusercontent.com/1465995/109130041-23db0f00-7706-11eb-9fb3-3508a76e6bec.png)

Changes:
- Navigation.yml - added 'VDP Programs' in header
- Programs.md - Included iframe within container that is called by navigation
- Navigation_boxes.yml - added extra button in main menu for linking to programs page
- programs-datatable-standalone.html - Actual datatables page

