### PR TITLE
Fix Voatz letter link

### DIFF
--- a/docs/voatz-response-letter/index.md
+++ b/docs/voatz-response-letter/index.md
@@ -1,0 +1,5 @@
+---
+permalink: /
+redirect_to:
+  - "https://disclose.io/uploads/voatz-response-letter.pdf"
+---


### PR DESCRIPTION
Adds backwards compatibility, so that https://disclose.io/voatz-response-letter/ (with the trailing slash) also redirects to the Voatz letter. Right now it gives a 404.