### PR TITLE
fixed social links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -112,11 +112,11 @@ authors:
 
 # Social icons displayed in footer
 social:
-    email:          hello@disclose.io
+    email:          mailto:hello@disclose.io
     website:        https://disclose.io
     facebook:       https://www.facebook.com/disclose-io
     github:         https://github.com/disclose
-    linkedin:       https://www.facebook.com/discloseio
+    linkedin:       https://www.linkedin.com/company/disclose-io/
     twitter:        https://twitter.com/disclose_io
     youtube:        https://www.youtube.com/c/discloseio
 


### PR DESCRIPTION
The links in the social icons at the bottom are currently broken. The email address doesn't have a mailto: schema, so it assumes that the email address is a directory name, and the linkedin icon links to Facebook.

Both are fixed in the config file in this PR